### PR TITLE
deleteCalendar method for calendar object

### DIFF
--- a/calendar_reboot.js
+++ b/calendar_reboot.js
@@ -248,6 +248,8 @@ $(document).ready(function() {
             var currentCalendarId = loadFromLocalStorage(current_active_calendar);
             removeFromCalendarDropdown(currentCalendarId);
             
+            
+            //below does not work
             calendar.deleteCalendar();
             calendar.removeActiveCalendar();
             

--- a/calendar_reboot.js
+++ b/calendar_reboot.js
@@ -1,4 +1,6 @@
 var masterKey = 'masterKey';
+//the current_active_calendar is the key for localStorage that stores
+//the active calendar's Id
 var current_active_calendar = 'current_active_calendar';
 
 $(document).ready(function() {
@@ -184,6 +186,7 @@ $(document).ready(function() {
             
             //make calendar object
             var calendar = new Calendar(calendarState);
+            console.log(calendar);
             calendar.setActiveCalendar();
             calendar.saveCalendar();
             
@@ -243,15 +246,11 @@ $(document).ready(function() {
         if (confirmation === true) {
             
             var currentCalendarId = loadFromLocalStorage(current_active_calendar);
-            console.log(currentCalendarId);
-            delete calendarUniqueId[currentCalendarId];
-            storeInLocalStorage(masterKey, calendarUniqueId);
-            
             removeFromCalendarDropdown(currentCalendarId);
-            //remove the calendarstate from localStorage
-            removeFromLocalStorage(currentCalendarId);
             
-            removeFromLocalStorage(current_active_calendar);
+            calendar.deleteCalendar();
+            calendar.removeActiveCalendar();
+            
             
             console.log("clearing the page");
             //clear the page
@@ -674,14 +673,22 @@ Calendar.prototype.fillCalendar = function(monthObjectsArray) {
 
 
 Calendar.prototype.setActiveCalendar = function() {
-    
+    var self = this;
     //set the current active calendar 
     storeInLocalStorage(current_active_calendar, self.calendarState.uniqueId);
+};
+
+Calendar.prototype.removeActiveCalendar = function() {
+    //removes a calendar from current_active_calendar status. It will no
+    //longer be stored in LocalStorage as the current_active_calendar
+    var self = this;
+    removeFromLocalStorage(current_active_calendar);
+    
 };
     
 Calendar.prototype.saveCalendar = function() {
         //saves the calendar in localStorage, saves the calendarUniqueId object
-        //adds the calendar to the saved calendars dropdown
+        
         var self = this;
         //store the state in localStorage
         storeInLocalStorage(self.calendarState.uniqueId, self.calendarState);
@@ -690,7 +697,23 @@ Calendar.prototype.saveCalendar = function() {
         calendarUniqueId[self.calendarState.uniqueId] = self.calendarState.calendarTitle;
         storeInLocalStorage(masterKey, calendarUniqueId);
         
-    };
+};
+    
+Calendar.prototype.deleteCalendar = function() {
+    //deletes the calendar from localStorage, deletes the calendar from the
+    //calendarUniqueId object
+    
+    var self = this;
+    //delete the calendar from the calendarUniqueId object
+    delete calendarUniqueId[calendar.calendarState.uniqueId];
+    //save that change in localstorage
+    storeInLocalStorage(masterKey, calendarUniqueId);
+    
+    //remove the calendarstate from localStorage
+    removeFromLocalStorage(calendar.calendarState.uniqueId);
+
+}
+    
 
 //dictionary of savedCalendars, calendar title: unique ID
 

--- a/calendar_reboot.js
+++ b/calendar_reboot.js
@@ -675,48 +675,6 @@ Calendar.prototype.fillCalendar = function(monthObjectsArray) {
     });
 };
 
-
-Calendar.prototype.setActiveCalendar = function() {
-    var self = this;
-    //set the current active calendar 
-    storeInLocalStorage(current_active_calendar, self.state.uniqueId);
-};
-
-Calendar.prototype.removeActiveCalendar = function() {
-    //removes a calendar from current_active_calendar status. It will no
-    //longer be stored in LocalStorage as the current_active_calendar
-    var self = this;
-    removeFromLocalStorage(current_active_calendar);
-    
-};
-    
-Calendar.prototype.saveCalendar = function() {
-        //saves the calendar in localStorage, saves the allCalendarIds object
-        
-        var self = this;
-        //store the state in localStorage
-        storeInLocalStorage(self.state.uniqueId, self.state);
-        
-        //put calendar in allCalendarIdss and store it
-        allCalendarIds[self.state.uniqueId] = self.state.title;
-        storeInLocalStorage(allCalendarIdsKey, allCalendarIds);
-        
-};
-    
-Calendar.prototype.deleteCalendar = function() {
-    //deletes the calendar from localStorage, deletes the calendar from the
-    //allCalendarIds object
-    
-    var self = this;
-    //delete the calendar from the allCalendarIds object
-    delete allCalendarIds[self.state.uniqueId];
-    //save that change in localstorage
-    storeInLocalStorage(allCalendarIdsKey, allCalendarIds);
-    
-    //remove the calendarstate from localStorage
-    removeFromLocalStorage(self.state.uniqueId);
-
-}
     
 
 //dictionary of savedCalendars, calendar title: unique ID

--- a/calendar_reboot.js
+++ b/calendar_reboot.js
@@ -146,7 +146,7 @@ $(document).ready(function() {
         
         clearPage();
         buildCalendar(calendarObj);
-        store.setActive(calendarObj);
+        store.setActiveById(calendarObj.state.uniqueId);
         store.save(calendarObj);
     };
     
@@ -183,7 +183,7 @@ $(document).ready(function() {
 
             var calendar = new Calendar(state);
             
-            store.setActive(calendar);
+            store.setActiveById(calendar.state.uniqueId);
             store.save(calendar);
 
             
@@ -222,18 +222,6 @@ $(document).ready(function() {
         //deletes the current calendar on display, removes
         //the name from the saved calendars dropdown
         
-        //when you delete a calendar, it needs to be removed from local Storage
-        //it's unique Id needs to be removed from the allCalendarIds dictionary
-        //it's name needs to be removed from the saved calendars dropdown
-        //clear the calendar from the page and uncollapse build calendar
-        
-        //need to check if there is a calendar loaded that needs to be deleted.
-        //in other words, are we currently looking at a calendar? (you can't
-        //have a calendar be loaded without it being displayed on the screen)
-        //to check maybe we can check if calendarState's uniqueId exists
-        //in the allCalendarIds dictionary, because if it isn't then this is
-        //not a saved calendar
-        
         //ask the user if they are sure they want to delete their calendar
         var confirmation = confirm("Are you sure you want to delete your calendar?");
         if (confirmation) {
@@ -247,7 +235,6 @@ $(document).ready(function() {
             
             //delete the calendar and remove it's active calendar status
             store.remove(calendar);
-            store.removeActiveStatus(calendar);
             
             console.log("clearing the page");
             //clear the page
@@ -708,6 +695,9 @@ var LocalCalendarStorage = function(params) {
         
         //remove the object's state from localStorage
         removeFromLocalStorage(toKey(calendarObj.state.uniqueId));
+        
+        //remove active status from the calendar
+        removeFromLocalStorage(toKey(current_active_calendar));
     };
     
     self.load = function(calendarObj) {
@@ -721,11 +711,6 @@ var LocalCalendarStorage = function(params) {
         return loadFromLocalStorage(toKey(calendarObjId));
     };
     
-    self.setActive = function(calendarObj) {
-        //set an app object (calendar) as the current_active object/calendar
-        storeInLocalStorage(toKey(current_active_calendar), calendarObj.state.uniqueId);
-    };
-    
     self.getActive = function() {
         //return the active_calendar id
         return loadFromLocalStorage(toKey(current_active_calendar));
@@ -736,10 +721,6 @@ var LocalCalendarStorage = function(params) {
         storeInLocalStorage(toKey(current_active_calendar), calendarObjId);
     };
     
-    self.removeActiveStatus = function(calendarObj) {
-        //remove the app object's status as the current_active object
-        removeFromLocalStorage(toKey(current_active_calendar));
-    }
     
 };
 

--- a/calendar_reboot.js
+++ b/calendar_reboot.js
@@ -1,11 +1,11 @@
-var masterKey = 'masterKey';
+var allCalendarIdsKey = 'allCalendarIdsKey';
 //the current_active_calendar is the key for localStorage that stores
 //the active calendar's Id
 var current_active_calendar = 'current_active_calendar';
 
 $(document).ready(function() {
     
-    //will need to use a better key than this for masterKey (if this is
+    //will need to use a better key than this for allCalendarIdsKey (if this is
     //even a good way to do this)
     
     
@@ -35,7 +35,7 @@ $(document).ready(function() {
         //add the calendar with unique Id, uniqueId, and title, title, to
         //the saved calendars dropdown on the navbar.
         
-        console.log("adding calendar to dropdown");
+        
         $('#calendarDropdown').append('<li id="' + uniqueId
                 + '"><a href=#>' + title + '</a></li>');
     };
@@ -134,23 +134,20 @@ $(document).ready(function() {
     var buildCalendar = function(calendarObject) {
         // builds the front end of a calendar object. creates the html
         //this function assumes the calendarObject already has it's
-        //calendarState updated with the correct information. 
+        //state updated with the correct information. 
         
         calendarObject.generateEmptyCalendar(calendarObject.monthObjects);
         calendarObject.fillCalendar(calendarObject.monthObjects);
         
     };
     
-    var displayCalendar = function(uniqueId) {
-        //load a calendarState and build the calendar on the page
-        
-        var state = loadFromLocalStorage(uniqueId);
-        var calendar = new Calendar(state);
+    var displayCalendar = function(calendarObj) {
+        //load a state and build the calendar on the page
         
         clearPage();
-        buildCalendar(calendar);
-        calendar.setActiveCalendar();
-        calendar.saveCalendar();
+        buildCalendar(calendarObj);
+        store.setActive(calendarObj);
+        store.save(calendarObj);
     };
     
     $('#clearButton').click(function() {
@@ -160,20 +157,20 @@ $(document).ready(function() {
     });
     
     $('#setButton').click(function(){
-        console.log("set Button clicked");
+        
         //take the empty calendar object made when the page is loaded
         // and fill it with the information given in the form
         //required info are startDate and title. default to tracking 1 
         //year
-        var calendarTitle = $("#calendarTitle").val();
-        var startDate = $("#startDate").val();
-        var endDate = $("#endDate").val();
+        var title = $("#calendarTitle").val();
+        var start = $("#startDate").val();
+        var end = $("#endDate").val();
             
         
         var validateTitle = validateInput(calendarTitleId);
         var validateStartDate = validateInput(startDateId);
         var validateEndDate = validateInput(endDateId);
-        var validateDates = validateForm(startDate, endDate);
+        var validateDates = validateForm(start, end);
         
         if (validateTitle && validateStartDate && validateEndDate && validateDates) {
             //clear the previously displayed calendar <-- or should i reload the page???
@@ -181,20 +178,20 @@ $(document).ready(function() {
         
             
             //make a calendar State
-            var calendarState = emptyCalendarState(startDate, endDate, calendarTitle);
+            var state = emptyCalendarState({startDate: start, endDate: end, calendarTitle: title});
             
             
             //make calendar object
-            var calendar = new Calendar(calendarState);
-            console.log(calendar);
-            calendar.setActiveCalendar();
-            calendar.saveCalendar();
+            var calendar = new Calendar(state);
+            
+            store.setActive(calendar);
+            store.save(calendar);
             
             //add calendar to dropdown
-            addCalendarToDropdown(calendar.calendarState.uniqueId, calendar.calendarState.calendarTitle);
+            addCalendarToDropdown(calendar.state.uniqueId, calendar.state.title);
         
             //build the calendar
-           buildCalendar(calendar);
+            buildCalendar(calendar);
        }
     });
     
@@ -208,19 +205,15 @@ $(document).ready(function() {
         //calendar
         
         //load the saved calendar with the title that was clicked
-    
-        console.log("the storage key you are using " + $(this).attr('id'));
-        var loadedCalendarState = loadFromLocalStorage($(this).attr('id'));
         
-        if (loadedCalendarState === null) {
-            console.error('calendar does not exist/has not been saved');
-        }
-        else {
-            displayCalendar($(this).attr('id'));
-            $('#collapseOne').collapse('hide'); 
-
-        }
+        var dropdownItemId = $(this).attr('id');
         
+        var state = store.loadById(dropdownItemId);
+        
+        var calendar = new Calendar(state);
+        
+        displayCalendar(calendar);
+        $('#collapseOne').collapse('hide'); 
         
     });
 
@@ -230,7 +223,7 @@ $(document).ready(function() {
         //the name from the saved calendars dropdown
         
         //when you delete a calendar, it needs to be removed from local Storage
-        //it's unique Id needs to be removed from the calendarUniqueId dictionary
+        //it's unique Id needs to be removed from the allCalendarIds dictionary
         //it's name needs to be removed from the saved calendars dropdown
         //clear the calendar from the page and uncollapse build calendar
         
@@ -238,21 +231,23 @@ $(document).ready(function() {
         //in other words, are we currently looking at a calendar? (you can't
         //have a calendar be loaded without it being displayed on the screen)
         //to check maybe we can check if calendarState's uniqueId exists
-        //in the calendarUniqueId dictionary, because if it isn't then this is
+        //in the allCalendarIds dictionary, because if it isn't then this is
         //not a saved calendar
         
         //ask the user if they are sure they want to delete their calendar
         var confirmation = confirm("Are you sure you want to delete your calendar?");
-        if (confirmation === true) {
+        if (confirmation) {
             
             var currentCalendarId = loadFromLocalStorage(current_active_calendar);
             removeFromCalendarDropdown(currentCalendarId);
             
+            //load calendarState from local storage and make a calendar object
+            var calendarState = loadFromLocalStorage(currentCalendarId);
+            var calendar = new Calendar(calendarState);
             
-            //below does not work
-            calendar.deleteCalendar();
-            calendar.removeActiveCalendar();
-            
+            //delete the calendar and remove it's active calendar status
+            store.remove(calendar);
+            store.removeActiveStatus(calendar);
             
             console.log("clearing the page");
             //clear the page
@@ -265,27 +260,34 @@ $(document).ready(function() {
     
     
     //WHEN PAGE LOADS
-    //first load the calendarUniqueId from storage.
-    calendarUniqueId = loadFromLocalStorage(masterKey);
+    //first load the allCalendarIds from storage.
+    allCalendarIds = store.getAllCalendarIds();
     //if it's not in localstorage make it an empty object
-    if (calendarUniqueId === null) {
-        calendarUniqueId = {};
+    if (allCalendarIds === null) {
+        allCalendarIds = {};
     }
     
-    //GOING THROUGH THE KEYS OF THE DICTIONARY calendarUniqueId
-    for (var key in calendarUniqueId) {
-      if (calendarUniqueId.hasOwnProperty(key)) {
+    //GOING THROUGH THE KEYS OF THE DICTIONARY allCalendarIds
+    for (var key in allCalendarIds) {
+      if (allCalendarIds.hasOwnProperty(key)) {
           if (key !== current_active_calendar) {
-            addCalendarToDropdown(key, calendarUniqueId[key]);
+            addCalendarToDropdown(key, allCalendarIds[key]);
           }
       }
     }
     
+    //get the current_active calendar id from storage if any
+    var activeCalendarId = store.getActive();
     
-    var activeCalendar = loadFromLocalStorage(current_active_calendar);
-    
-    if (activeCalendar !== null) {
-        displayCalendar(activeCalendar);
+    if (activeCalendarId !== null) {
+        console.log("the activeCalendarKey was not null");
+        var activeCalendarState = store.loadById(activeCalendarId);
+        
+        if (activeCalendarState !== null) {
+            var state = activeCalendarState;
+            var calendar = new Calendar(state);
+            displayCalendar(calendar);
+        }
         
     }
     
@@ -328,7 +330,7 @@ var loadFromLocalStorage = function(storageItemKey) {
         
     if (storageItem === null) 
     {
-        console.log(storageItemKey + "not found in localstorage");
+        console.log(storageItemKey + " not found in localstorage");
         return storageItem;   
     }
                                                                                                    
@@ -440,22 +442,22 @@ var Month = function(dateString, calendarObj) {
             var boxId = $( this).attr('id');
             //if the boxId is not checked (as in, the value is not inside of checkedDays
             //in other words, it's undefined
-            if (self.calendar.calendarState.checkedDays[boxId] === undefined) {
+            if (self.calendar.state.checkedDays[boxId] === undefined) {
                 //add it to checkedDays
-                self.calendar.calendarState.checkedDays[boxId] = 1;
+                self.calendar.state.checkedDays[boxId] = 1;
                 //then add a checkmark
                 $( this ).children('.element').removeClass("hidden");
             }
             else {
                 //remove from checkedDays
-                delete self.calendar.calendarState.checkedDays[boxId]
+                delete self.calendar.state.checkedDays[boxId]
                 //remove the checkmark from the page
                 $( this ).children('.element').addClass("hidden");
             }
             
             //save your progress
             
-            self.calendar.saveCalendar();
+            store.save(self.calendar);
          })
      };
 
@@ -533,7 +535,7 @@ var Month = function(dateString, calendarObj) {
         {
             var boxId = $(this).attr('id');
             
-            if (self.calendar.calendarState.checkedDays[$(this).attr('id')]) 
+            if (self.calendar.state.checkedDays[$(this).attr('id')]) 
             {
                 $(this).children('.element').removeClass("hidden");
             }
@@ -573,7 +575,7 @@ var makeCalendarObj = function(state) {
     var startDate = state.startDate;
     var numberOfYears = state.numberOfYears;
     var calendar = new Calendar(startDate, numberOfYears);
-    calendar.calendarState = state;
+    calendar.state = state;
     return calendar;
 };
 
@@ -584,7 +586,7 @@ var extractCalendarState = function(calendarObj) {
     // calendarObj: object
     //     An instance of the Calendar class
     
-    return calendarObj.calendarState;
+    return calendarObj.state;
 };
 
 var generateUniqueId = function() {
@@ -593,13 +595,13 @@ var generateUniqueId = function() {
     
 };
 
-var emptyCalendarState = function(startDate, endDate, title) {
+var emptyCalendarState = function(params) {
     return{
         //"YYYYMMDD" string
-        startDateString: moment(startDate, "YYYY-MM-DD").format("YYYYMMDD"),
-        endDateString: moment(endDate, "YYYY-MM-DD").format("YYYYMMDD"),
+        startDateString: moment(params.startDate, "YYYY-MM-DD").format("YYYYMMDD"),
+        endDateString: moment(params.endDate, "YYYY-MM-DD").format("YYYYMMDD"),
         //list name under which it will be saved
-        calendarTitle: title,
+        title: params.calendarTitle,
         //unique ID for calendar
         uniqueId: generateUniqueId(),
         //checkedDays day id: 1
@@ -610,7 +612,7 @@ var emptyCalendarState = function(startDate, endDate, title) {
 var Calendar = function(state) {
     
     var self = this;
-    self.calendarState = state;
+    self.state = state;
     //startDate is a moment object , the argument startDateString is 
     //"YYYYMMDD" string
     self.startDate = moment(state.startDateString, "YYYYMMDD");
@@ -619,7 +621,7 @@ var Calendar = function(state) {
     //number of months we will need to be able to cover all the years the
     //user wants to track
     self.numberOfMonths = self.endDate.diff(self.startDate, 'months', true);
-    self.title = state.calendarTitle;
+    self.title = state.title;
     self.monthObjects = self.generateMonthObjects();
     
 }
@@ -652,7 +654,7 @@ Calendar.prototype.generateEmptyCalendar = function(monthObjectsArray) {
     var $div = $('#calendarDiv');
 
     $div.append('<div id="calendarTitleHeading"> <h1 class="page-header text-center">' +
-              self.calendarState.calendarTitle + '</h1></div>');
+              self.state.title + '</h1></div>');
     
     monthObjectsArray.forEach (function(monthObj, index) {
         var isFirst = index === 0;
@@ -677,7 +679,7 @@ Calendar.prototype.fillCalendar = function(monthObjectsArray) {
 Calendar.prototype.setActiveCalendar = function() {
     var self = this;
     //set the current active calendar 
-    storeInLocalStorage(current_active_calendar, self.calendarState.uniqueId);
+    storeInLocalStorage(current_active_calendar, self.state.uniqueId);
 };
 
 Calendar.prototype.removeActiveCalendar = function() {
@@ -689,39 +691,114 @@ Calendar.prototype.removeActiveCalendar = function() {
 };
     
 Calendar.prototype.saveCalendar = function() {
-        //saves the calendar in localStorage, saves the calendarUniqueId object
+        //saves the calendar in localStorage, saves the allCalendarIds object
         
         var self = this;
         //store the state in localStorage
-        storeInLocalStorage(self.calendarState.uniqueId, self.calendarState);
+        storeInLocalStorage(self.state.uniqueId, self.state);
         
-        //put calendar in calendarUniqueIds and store it
-        calendarUniqueId[self.calendarState.uniqueId] = self.calendarState.calendarTitle;
-        storeInLocalStorage(masterKey, calendarUniqueId);
+        //put calendar in allCalendarIdss and store it
+        allCalendarIds[self.state.uniqueId] = self.state.title;
+        storeInLocalStorage(allCalendarIdsKey, allCalendarIds);
         
 };
     
 Calendar.prototype.deleteCalendar = function() {
     //deletes the calendar from localStorage, deletes the calendar from the
-    //calendarUniqueId object
+    //allCalendarIds object
     
     var self = this;
-    //delete the calendar from the calendarUniqueId object
-    delete calendarUniqueId[calendar.calendarState.uniqueId];
+    //delete the calendar from the allCalendarIds object
+    delete allCalendarIds[self.state.uniqueId];
     //save that change in localstorage
-    storeInLocalStorage(masterKey, calendarUniqueId);
+    storeInLocalStorage(allCalendarIdsKey, allCalendarIds);
     
     //remove the calendarstate from localStorage
-    removeFromLocalStorage(calendar.calendarState.uniqueId);
+    removeFromLocalStorage(self.state.uniqueId);
 
 }
     
 
 //dictionary of savedCalendars, calendar title: unique ID
 
-var calendarUniqueId = {
+var allCalendarIds = {
 };
 
+//Make a storage manager
+var LocalCalendarStorage = function(params) {
+    var self = this;
+    var prefix = params['storeId'] || "";
+    
+    //params.storeId
+    
+    var toKey = function(id) {
+        //make a key out of a uniqueId
+        
+        return prefix + "_" + id;
+        
+    };
+    
+    self.getAllCalendarIds = function() {
+        //gets the allCalendarIds object from storage
+        
+        return loadFromLocalStorage(toKey(allCalendarIdsKey));
+    };
+    
+    self.save = function(appObj) {
+        //save an App object (like a calendar object for example) in storage
+        
+        //store the state in localStorage
+        storeInLocalStorage(toKey(appObj.state.uniqueId), appObj.state);
+        
+        //put calendar in allCalendarIdss and store it
+        allCalendarIds[appObj.state.uniqueId] = appObj.state.title;
+        storeInLocalStorage(toKey(allCalendarIdsKey), allCalendarIds);
+    };
+    
+    self.remove = function(appObj) {
+        //remove an app object (like a calendar) from storage
+        
+        //delete the calendar from the allCalendarIds object
+        delete allCalendarIds[appObj.state.uniqueId];
+        //save that change in localstorage
+        storeInLocalStorage(toKey(allCalendarIdsKey), allCalendarIds);
+        
+        //remove the object's state from localStorage
+        removeFromLocalStorage(toKey(appObj.state.uniqueId));
+    };
+    
+    self.load = function(appObj) {
+        //load an App object ( like a calendar object)
+        
+        return loadFromLocalStorage(toKey(appObj.uniqueId));
+    };
+    
+    self.loadById = function(appObjId) {
+        //load an App object using it's Id
+        return loadFromLocalStorage(toKey(appObjId));
+    };
+    
+    self.setActive = function(appObj) {
+        //set an app object (calendar) as the current_active object/calendar
+        storeInLocalStorage(toKey(current_active_calendar), appObj.state.uniqueId);
+    };
+    
+    self.getActive = function() {
+        //return the active_calendar id
+        return loadFromLocalStorage(toKey(current_active_calendar));
+    };
+    
+    self.setActiveById = function(appObjId) {
+        //set the active calendar/object by using it's Id
+        storeInLocalStorage(toKey(current_active_calendar), appObjId);
+    };
+    
+    self.removeActiveStatus = function(appObj) {
+        //remove the app object's status as the current_active object
+        removeFromLocalStorage(toKey(current_active_calendar));
+    }
+    
+};
 
-
+var store = new LocalCalendarStorage({'storeId': 'Streaker'})
 

--- a/calendar_reboot.js
+++ b/calendar_reboot.js
@@ -261,12 +261,8 @@ $(document).ready(function() {
     
     //WHEN PAGE LOADS
     //first load the allCalendarIds from storage.
-    allCalendarIds = store.getAllCalendarIds();
-    //if it's not in localstorage make it an empty object
-    if (allCalendarIds === null) {
-        allCalendarIds = {};
-    }
-    
+    allCalendarIds = store.getAllCalendarIds() || {};
+   
     //GOING THROUGH THE KEYS OF THE DICTIONARY allCalendarIds
     for (var key in allCalendarIds) {
       if (allCalendarIds.hasOwnProperty(key)) {
@@ -280,7 +276,7 @@ $(document).ready(function() {
     var activeCalendarId = store.getActive();
     
     if (activeCalendarId !== null) {
-        console.log("the activeCalendarKey was not null");
+        
         var activeCalendarState = store.loadById(activeCalendarId);
         
         if (activeCalendarState !== null) {
@@ -566,18 +562,6 @@ var Month = function(dateString, calendarObj) {
 
 //generate a year/multiple years
 
-var makeCalendarObj = function(state) {
-    // Returns a calendar object with the given state as it's calendarState.
-    
-    // Parameters:
-    // state: dictionary
-    //     contains calendar information (numberOfYears, startDate, etc)
-    var startDate = state.startDate;
-    var numberOfYears = state.numberOfYears;
-    var calendar = new Calendar(startDate, numberOfYears);
-    calendar.state = state;
-    return calendar;
-};
 
 var extractCalendarState = function(calendarObj) {
     // Takes a calendar object, extracts it's calendarState, and returns it.
@@ -621,7 +605,6 @@ var Calendar = function(state) {
     //number of months we will need to be able to cover all the years the
     //user wants to track
     self.numberOfMonths = self.endDate.diff(self.startDate, 'months', true);
-    self.title = state.title;
     self.monthObjects = self.generateMonthObjects();
     
 }
@@ -702,43 +685,43 @@ var LocalCalendarStorage = function(params) {
         return loadFromLocalStorage(toKey(allCalendarIdsKey));
     };
     
-    self.save = function(appObj) {
+    self.save = function(calendarObj) {
         //save an App object (like a calendar object for example) in storage
         
         //store the state in localStorage
-        storeInLocalStorage(toKey(appObj.state.uniqueId), appObj.state);
+        storeInLocalStorage(toKey(calendarObj.state.uniqueId), calendarObj.state);
         
         //put calendar in allCalendarIdss and store it
-        allCalendarIds[appObj.state.uniqueId] = appObj.state.title;
+        allCalendarIds[calendarObj.state.uniqueId] = calendarObj.state.title;
         storeInLocalStorage(toKey(allCalendarIdsKey), allCalendarIds);
     };
     
-    self.remove = function(appObj) {
+    self.remove = function(calendarObj) {
         //remove an app object (like a calendar) from storage
         
         //delete the calendar from the allCalendarIds object
-        delete allCalendarIds[appObj.state.uniqueId];
+        delete allCalendarIds[calendarObj.state.uniqueId];
         //save that change in localstorage
         storeInLocalStorage(toKey(allCalendarIdsKey), allCalendarIds);
         
         //remove the object's state from localStorage
-        removeFromLocalStorage(toKey(appObj.state.uniqueId));
+        removeFromLocalStorage(toKey(calendarObj.state.uniqueId));
     };
     
-    self.load = function(appObj) {
+    self.load = function(calendarObj) {
         //load an App object ( like a calendar object)
         
-        return loadFromLocalStorage(toKey(appObj.uniqueId));
+        return loadFromLocalStorage(toKey(calendarObj.uniqueId));
     };
     
-    self.loadById = function(appObjId) {
+    self.loadById = function(calendarObjId) {
         //load an App object using it's Id
-        return loadFromLocalStorage(toKey(appObjId));
+        return loadFromLocalStorage(toKey(calendarObjId));
     };
     
-    self.setActive = function(appObj) {
+    self.setActive = function(calendarObj) {
         //set an app object (calendar) as the current_active object/calendar
-        storeInLocalStorage(toKey(current_active_calendar), appObj.state.uniqueId);
+        storeInLocalStorage(toKey(current_active_calendar), calendarObj.state.uniqueId);
     };
     
     self.getActive = function() {
@@ -746,12 +729,12 @@ var LocalCalendarStorage = function(params) {
         return loadFromLocalStorage(toKey(current_active_calendar));
     };
     
-    self.setActiveById = function(appObjId) {
+    self.setActiveById = function(calendarObjId) {
         //set the active calendar/object by using it's Id
-        storeInLocalStorage(toKey(current_active_calendar), appObjId);
+        storeInLocalStorage(toKey(current_active_calendar), calendarObjId);
     };
     
-    self.removeActiveStatus = function(appObj) {
+    self.removeActiveStatus = function(calendarObj) {
         //remove the app object's status as the current_active object
         removeFromLocalStorage(toKey(current_active_calendar));
     }


### PR DESCRIPTION
also wrote removeActiveCalendar as a calendar object method. setActiveCalendar is already a method on calendar object. These methods remove the calendar from current_active_status or stores it as such respectively.

Not sure if they should be calendar object methods though.
Also, I wrote the deleteCalendar method and want to use it in the deleteButton click handler. To do that I'd need to create a calendar object. 

The first thing that happens in the deleteButton click handler is that the current_active_calendar Id is loaded from storage. So, I could use that Id, to load the calendarState from storage, and then make a calendar object using that state. THEN use the delete method using that calendar object.

Should I go about it in that way? @johntyree 

(also added var self = this in the new methods I had written)